### PR TITLE
fix: rubygem typo

### DIFF
--- a/docs/sdk/sdk.mdx
+++ b/docs/sdk/sdk.mdx
@@ -112,7 +112,7 @@ try {
 Add this line to your application's Gemfile:
 
 ```ruby terminal
-$ gem 'convoy'
+$ gem 'convoy.rb'
 ```
 
 And then execute:
@@ -124,7 +124,7 @@ $ bundle install
 Or install it yourself as:
 
 ```ruby terminal
-$ gem install convoy
+$ gem install convoy.rb
 ```
 
 ### Configure


### PR DESCRIPTION
Resolves https://github.com/frain-dev/convoy-website/issues/377.