### PR TITLE
fix: update Mintlify canonical URL to www.getconvoy.io and add missing docs redirect

### DIFF
--- a/docs/docs.json
+++ b/docs/docs.json
@@ -314,6 +314,11 @@
       "linkedin": "https://www.linkedin.com/company/convoy-webhooks/"
     }
   },
+  "seo": {
+    "metatags": {
+      "canonical": "https://www.getconvoy.io"
+    }
+  },
   "integrations": {
     "posthog": {
       "apiKey": "phc_X7uV1sRNzjoTmWp8uXYrzrfrdUtGdMRTEEklRNt04eb",

--- a/vercel.json
+++ b/vercel.json
@@ -51,6 +51,16 @@
 			"permanent": true
 		},
 		{
+			"source": "/home/:match*",
+			"destination": "/docs/home/:match*",
+			"permanent": true
+		},
+		{
+			"source": "/business-and-enterprise/:match*",
+			"destination": "/docs/business-and-enterprise/:match*",
+			"permanent": true
+		},
+		{
 			"source": "/legal/support-policy",
 			"destination": "/docs/legal/support-policy",
 			"permanent": true


### PR DESCRIPTION
- Updated the custom domain in the Mintlify dashboard from docs.getconvoy.io to getconvoy.io
- Added seo.metatags.canonical in docs.json to override the canonical to www.getconvoy.io (matching our sitemap and serving domain)
- Added two missing redirect rules in vercel.json for /home/* and /business-and-enterprise/* docs paths that were returning 404