### PR TITLE
Fix sitemap: normalize Mintlify doc URLs before joining base URL

### DIFF
--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -1,6 +1,30 @@
 import { getAllRoutes, getPosts } from '@/lib/getPosts';
 import { getAllChangelogSlugs } from '@/lib/changelog';
 
+/** Mintlify <loc> values may be absolute (e.g. https://getconvoy.io/docs/...). Strip origin so we never concatenate base URL onto a full URL. */
+function mintlifyLocToPath(loc: string): string | null {
+	let s = loc.trim().replace(/&amp;/g, '&');
+	if (!s.startsWith('http://') && !s.startsWith('https://')) {
+		return s.startsWith('/') ? s : `/${s}`;
+	}
+	try {
+		const u = new URL(s);
+		const host = u.hostname.toLowerCase();
+		const isOurSite =
+			host === 'getconvoy.io' ||
+			host.endsWith('.getconvoy.io') ||
+			host === 'convoy.mintlify.app' ||
+			host.endsWith('.mintlify.app');
+		if (!isOurSite) {
+			return null;
+		}
+		const path = u.pathname + u.search + u.hash;
+		return path.length > 0 ? path : '/';
+	} catch {
+		return null;
+	}
+}
+
 export default async function sitemap() {
 	const URL = 'https://www.getconvoy.io';
 
@@ -57,8 +81,8 @@ export default async function sitemap() {
 			text
 				.match(/<loc>(.*?)<\/loc>/g)
 				?.map(loc => loc.replace(/<\/?loc>/g, ''))
-				?.map(url => url.replace('https://docs.getconvoy.io/docs', '/docs'))
-				?.filter(route => !shouldExcludeRoute(route))
+				?.map(mintlifyLocToPath)
+				?.filter((route): route is string => route !== null && !shouldExcludeRoute(route))
 				?.map(route => ({
 					url: `${URL}${route}`,
 					lastModified: new Date(),


### PR DESCRIPTION
The sitemap mixed two kinds of doc links: some were already full URLs from Mintlify, and our code added the site URL in front of them again. That created URLs with two https:// parts, which Google flagged.

We now turn Mintlify links into normal paths first, then add our domain once so every doc URL is a single valid link.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: isolated change to sitemap URL normalization to prevent malformed doc links; main risk is inadvertently dropping or mis-normalizing some Mintlify URLs via host allowlist/parsing.
> 
> **Overview**
> Fixes sitemap generation for docs by normalizing Mintlify `<loc>` entries into site-relative paths before prefixing the base domain, preventing double-`https://` URLs.
> 
> Adds `mintlifyLocToPath` to decode/trim, strip origins for allowed hosts, and drop external/invalid URLs, then applies this normalization and filtering when building the docs route list from Mintlify’s `sitemap.xml`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fdc94a922c1c322574d958386518dbaa3d95e308. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->